### PR TITLE
fix: add non-protected endpoint check to authentication logic

### DIFF
--- a/pages/api/action.js
+++ b/pages/api/action.js
@@ -4,6 +4,7 @@ import { baseDomain } from "src/api/client";
 import { isAllowedRoute, normalizeEndpoint } from "src/server/utils/allowedRoutes";
 import { getAuthToken } from "src/server/utils/authCookie";
 import { httpRequestMethods } from "src/server/utils/constants/httpsRequestMethods";
+import { checkIsNonProtectedEndpoint } from "src/utils/authUtils";
 import {
   isPasswordSameAsEmail,
   passwordMatchesEmailText,
@@ -69,10 +70,13 @@ export default async function handleAction(nextRequest, nextResponse) {
             ? nextRequest.headers.authorization
             : undefined;
 
+        // Non-protected endpoints (e.g. /validate-token) do not require auth
+        const isNonProtected = checkIsNonProtectedEndpoint(normalizedEndpoint);
+
         // No auth token → return 401 so client-side refresh logic triggers
         // (without this, the backend returns 400 "token is missing" which
         // the client doesn't treat as an auth failure)
-        if (!authorization) {
+        if (!authorization && !isNonProtected) {
           return nextResponse.status(401).json({ message: "Not authenticated" });
         }
 


### PR DESCRIPTION
fix #160 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed API authentication logic to properly handle non-protected endpoints. Non-protected endpoints are now accessible without authentication, while protected endpoints continue to require valid credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->